### PR TITLE
Fix timing of check for Facebook SDK access token

### DIFF
--- a/AccountKit_SampleApp_addFacebookLogin/AccountKit_SampleApp/LoginViewController.swift
+++ b/AccountKit_SampleApp_addFacebookLogin/AccountKit_SampleApp/LoginViewController.swift
@@ -183,9 +183,13 @@ extension LoginViewController: FBSDKLoginButtonDelegate {
             print("Login failed with error: \(error)")
         }
 
-        // The FBSDKAccessToken will be available, so we can navigate to the
-        // account view controller
-        presentWithSegueIdentifier("showAccount", animated: true)
+        // The FBSDKAccessToken is expected to be available, so we can navigate
+        // to the account view controller
+        if result.token != nil {
+            presentWithSegueIdentifier("showAccount", animated: true)
+        } else {
+            print("FBSDK access token not available in loginButton:didCompleteWith:error:")
+        }
     }
 
     public func loginButtonDidLogOut(_ loginButton: FBSDKLoginButton!) {


### PR DESCRIPTION
This PR makes two changes:

- It fixes the timing of the check for the presence of a `FBSDKAccessToken` in `LoginViewController`. (144c4ed)
- It adjusts the automatic segue in `viewWillAppear` / `viewDidAppear` so that the segue doesn't occur whenever the user navigates back to the login view controller (3271690)

For the first issue, the previous checks in `viewWillAppear` / `viewDidAppear` were occurring before the access token was available. (It does seem to be available on subsequent launches, so I think this was just a timing issue.)

To resolve the issue, `LoginViewController` now conforms to `FBSDKLoginButtonDelegate`, and the segue is triggered from `loginButton(_:didCompleteWith:error:)`. (I added a defensive check in that method for the existence of the token, but it's an `IUO` on the result parameter, so I expect it should always be present.)

For the second issue, the calls in `viewWillAppear` and `viewDidAppear` were just removed in favour of one in `viewDidLoad`. This is still a little iffy, as this could cause the segue to be called if the view was dropped and reloaded. It might be better to include a property in the view controller to explicitly track the "first launch" state and only trigger the segue then... but I thought this might add a little noise to the class so didn't make this change.